### PR TITLE
Add a partition write call when the end of the block is reached

### DIFF
--- a/src/main/java/org/thingsboard/client/tools/migrator/writer/AbstractTbWriter.java
+++ b/src/main/java/org/thingsboard/client/tools/migrator/writer/AbstractTbWriter.java
@@ -101,6 +101,12 @@ public abstract class AbstractTbWriter implements TbWriter {
             currentLine = iterator.nextLine();
 
             if (WriterUtils.isBlockFinished(currentLine)) {
+
+                try {
+                    writePartitions();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
                 return linesToSkip;
             }
 
@@ -148,6 +154,11 @@ public abstract class AbstractTbWriter implements TbWriter {
                 }
                 log.error("Failed to process line [" + currentLine + "], skipping it , values = " + strValues + "", ex);
             }
+        }
+        try {
+            writePartitions();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
         return linesToSkip;
     }


### PR DESCRIPTION
On small databases smaller than 10000000 rows, the partition table will never be written. It is necessary to add a call to write partitions when the end of a block is reached. This will allow partition data to be written whether the line limit per file has been reached or not.