### PR TITLE
Add compatibility with timescaleDB and custom tables

### DIFF
--- a/src/main/java/org/thingsboard/client/tools/migrator/PgCaMigrator.java
+++ b/src/main/java/org/thingsboard/client/tools/migrator/PgCaMigrator.java
@@ -102,7 +102,7 @@ public class PgCaMigrator {
     }
 
     private boolean isBlockTsStarted(String line) {
-        return line.startsWith("COPY public.ts_kv (");
+        return line.startsWith("COPY public.ts_kv (") || line.startsWith("COPY _timescaledb_internal._hyper") || line.startsWith("COPY public.ts_kv_custom");
     }
 
     private boolean isBlockLatestStarted(String line) {


### PR DESCRIPTION
Added possibility to migrate not only postgres table ts_kv data, but also timescale and custom tables if some part of data needs to be migrated. 
Added documentation on the migration of custom tables.