### PR TITLE
DictionaryParser update for compatibility with version 3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Using `cqlsh` create `thingsboard` keyspace and required tables.
   ```
 * Dump `ts_kv_dictionary`:
   ```bash
-  pg_dump -h localhost -U postgres -d thingsboard --table=ts_kv_dictionary > /home/user/dump/ts_kv_dictionary.dmp
+  pg_dump -h localhost -U postgres -d thingsboard --table=ts_kv_dictionary --table=key_dictionary > /home/user/dump/ts_kv_dictionary.dmp
   ```
    
 * Dump `ts_kv` and all partitions:
@@ -227,7 +227,7 @@ Re-start ThingsBoard and verify that new timeseries data written into Cassandra.
   ```
 * Dump `ts_kv_dictionary`:
   ```bash
-  pg_dump -h localhost -U postgres -d thingsboard --table=ts_kv_dictionary > /home/user/dump/ts_kv_dictionary.dmp
+  pg_dump -h localhost -U postgres -d thingsboard --table=ts_kv_dictionary --table=key_dictionary > /home/user/dump/ts_kv_dictionary.dmp
   ```
 
 * Dump `ts_kv` and all partitions:

--- a/src/main/java/org/thingsboard/client/tools/migrator/DictionaryParser.java
+++ b/src/main/java/org/thingsboard/client/tools/migrator/DictionaryParser.java
@@ -53,7 +53,7 @@ public class DictionaryParser {
     }
 
     private boolean isBlockStarted(String line) {
-        return line.startsWith("COPY public.ts_kv_dictionary (");
+        return line.startsWith("COPY public.ts_kv_dictionary (") || line.startsWith("COPY public.key_dictionary (");
     }
 
     private void parseDictionaryDump(LineIterator iterator) throws IOException {


### PR DESCRIPTION
Due to the dictionary table update in version 3.7.0, it is required to back up the key_dictionary table in addition to ts_kv_dictionary. The backup will be successful if one of these tables exists, which does not require any additional actions on the user's side.