### PR TITLE
Upgrade Cassandra dependencies for new Bloom filter format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
         <guava.version>30.0-jre</guava.version>
         <slf4j.version>1.7.32</slf4j.version>
         <lombok.version>1.18.18</lombok.version>
-        <cassandra-all.version>3.11.9</cassandra-all.version>
-        <cassandra-driver-core.version>3.11.0</cassandra-driver-core.version>
+        <cassandra-all.version>4.0.0</cassandra-all.version>
+        <cassandra-driver-core.version>4.0.0</cassandra-driver-core.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
@@ -43,6 +43,7 @@
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
             <version>${cassandra-driver-core.version}</version>
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -96,6 +97,11 @@
     </build>
 
     <repositories>
+        <repository>
+            <id>maven-central</id>
+            <name>Maven Central</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
         <repository>
             <id>thingsboard</id>
             <url>https://repo.thingsboard.io/artifactory/libs-release-public</url>


### PR DESCRIPTION
Upgraded Cassandra `cassandra-all` and `java-driver-core` dependencies to 4.0.0 and 4.0.0 respectively to ensure compatibility with Cassandra 4 & 5's new Bloom filter format and internal SSTable structure.