### PR TITLE
Upgrade Writer to Cassandra 5; upgrade Java support to version 11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
 # Prerequisites
 
-**IMPORTANT! Requires Java 8 SDK**
+**Requires Java 11+ SDK (Java 17 recommended)**
 
-Please make sure you have JDK 8 installed:
+The tool needs Java 11 at minimum. JDK 17 is recommended, matching Cassandra
+5.0's own officially supported runtime. JDK 21 has been verified to work for this tool's
+offline SSTable-writing usage, but is not yet an officially supported JDK for Cassandra 5.0
+itself, so treat it as best-effort. JDK 8 is no longer supported.
+
+The bundled `cassandra-all` library needs reflective access to a few JDK-internal packages
+on JDK 9+; this is granted automatically via `Add-Opens`/`Add-Exports` entries in the jar
+manifest, so no extra JVM flags are needed when running with `java -jar`.
+
 
 ```
-ubuntu@pc:~$ java -version
-openjdk version "1.8.0_292"
-OpenJDK Runtime Environment (build 1.8.0_292-8u292-b10-0ubuntu1~20.04-b10)
-OpenJDK 64-Bit Server VM (build 25.292-b10, mixed mode)
+# Installing OpenJDK 17
+sudo apt update && sudo apt install -y openjdk-17-jdk-headless
+# Set Java 17 as the default version
+sudo update-alternatives --config java
+# Verify the installation
+java -version
 ```
 
 # Description
@@ -153,6 +163,8 @@ Tool execution time depends on DB size, CPU resources and disk throughput.
 ### Loading SSTables into Cassandra
 
 **Note that this part works only for single node Cassandra cluster**
+
+**This tool now generates SSTables in Cassandra 5's native big-format (`oa`) — the target Cassandra installation must be version 5.0.x.**
 
 * Stop Cassandra
 * Look at `/var/lib/cassandra/data/thingsboard` and check for names of data folders
@@ -310,7 +322,9 @@ Tool execution time depends on DB size, CPU resources and disk throughput.
 
 ### Loading SSTables into Cassandra
 
-Using [sstableloader](https://docs.datastax.com/en/cassandra-oss/3.x/cassandra/tools/toolsBulkloader.html) start loading data into Cassandra:
+**This tool now generates SSTables in Cassandra 5's native big-format (`oa`) — use the `sstableloader` that ships with your Cassandra 5.0.x installation (an older 3.x/4.x `sstableloader` binary will not understand the target cluster's streaming protocol).**
+
+Using [sstableloader](https://cassandra.apache.org/doc/5.0/cassandra/managing/tools/sstableloader.html) start loading data into Cassandra:
 
 ```
 sstableloader --verbose --nodes CASSANDRA_NODES --username cassandra --password CASSANDRA_PASSWORD /home/user/migration/thingsboard/ts_kv_partitions_cf/

--- a/pom.xml
+++ b/pom.xml
@@ -11,38 +11,25 @@
     <packaging>jar</packaging>
 
     <properties>
-        <lombok.version>1.18.18</lombok.version>
+        <lombok.version>1.18.46</lombok.version>
         <spring-boot.version>2.3.12.RELEASE</spring-boot.version>
         <commons-io.version>2.11.0</commons-io.version>
-        <guava.version>30.0-jre</guava.version>
         <slf4j.version>1.7.32</slf4j.version>
-        <lombok.version>1.18.18</lombok.version>
-        <cassandra-all.version>3.11.9</cassandra-all.version>
-        <cassandra-driver-core.version>3.11.0</cassandra-driver-core.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <cassandra-all.version>5.0.6</cassandra-all.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-            <version>${spring-boot.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
             <version>${cassandra-all.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
-            <artifactId>cassandra-driver-core</artifactId>
-            <version>${cassandra-driver-core.version}</version>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>32.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -75,6 +62,19 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -85,6 +85,13 @@
                             <manifest>
                                 <mainClass>org.thingsboard.client.tools.migrator.MigratorTool</mainClass>
                             </manifest>
+                            <manifestEntries>
+                                <!-- cassandra-all's NativeLibrary/UUIDGen reflect into these JDK-internal
+                                     packages; JDK 16+ strong encapsulation blocks that by default.
+                                     The java launcher applies these to unnamed modules for `java -jar`. -->
+                                <Add-Opens>java.base/java.io java.base/sun.nio.ch java.base/jdk.internal.ref</Add-Opens>
+                                <Add-Exports>java.base/sun.nio.ch</Add-Exports>
+                            </manifestEntries>
                         </archive>
                         <descriptorRefs>
                             <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -94,11 +101,4 @@
             </plugins>
         </pluginManagement>
     </build>
-
-    <repositories>
-        <repository>
-            <id>thingsboard</id>
-            <url>https://repo.thingsboard.io/artifactory/libs-release-public</url>
-        </repository>
-    </repositories>
 </project>

--- a/src/main/java/org/thingsboard/client/tools/migrator/WriterBuilder.java
+++ b/src/main/java/org/thingsboard/client/tools/migrator/WriterBuilder.java
@@ -74,7 +74,7 @@ public class WriterBuilder {
 
     public static CQLSSTableWriter getTsWriter(File dir) {
         return CQLSSTableWriter.builder()
-                .inDirectory(dir)
+                .inDirectory(dir.getAbsolutePath())
                 .forTable(tsSchema)
                 .using("INSERT INTO thingsboard.ts_kv_cf (entity_type, entity_id, key, partition, ts, bool_v, str_v, long_v, dbl_v, json_v) " +
                         "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
@@ -83,7 +83,7 @@ public class WriterBuilder {
 
     public static CQLSSTableWriter getLatestWriter(File dir) {
         return CQLSSTableWriter.builder()
-                .inDirectory(dir)
+                .inDirectory(dir.getAbsolutePath())
                 .forTable(latestSchema)
                 .using("INSERT INTO thingsboard.ts_kv_latest_cf (entity_type, entity_id, key, ts, bool_v, str_v, long_v, dbl_v, json_v) " +
                         "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")
@@ -92,7 +92,7 @@ public class WriterBuilder {
 
     public static CQLSSTableWriter getPartitionWriter(File dir) {
         return CQLSSTableWriter.builder()
-                .inDirectory(dir)
+                .inDirectory(dir.getAbsolutePath())
                 .forTable(partitionSchema)
                 .using("INSERT INTO thingsboard.ts_kv_partitions_cf (entity_type, entity_id, key, partition) " +
                         "VALUES (?, ?, ?, ?)")


### PR DESCRIPTION
The JDK version in the project configurations has been updated.
The Cassandra driver and related dependencies have been updated.